### PR TITLE
Fix issues #11, #13, #14: Parameter path memory, force save, PX4 support

### DIFF
--- a/flight_manager/services.py
+++ b/flight_manager/services.py
@@ -16,7 +16,8 @@ class LogService:
         flight_no: str,
         date: str,
         vehicle: str,
-        checklist_items: Dict[str, Dict[str, Any]]
+        checklist_items: Dict[str, Dict[str, Any]],
+        skip_checklist: bool = False,
     ) -> Tuple[bool, List[str]]:
         """Validates log entry data.
 
@@ -25,6 +26,7 @@ class LogService:
             date: The flight date.
             vehicle: The vehicle name.
             checklist_items: Dictionary of checklist widget data.
+            skip_checklist: When True, bypasses preflight check validation.
 
         Returns:
             A tuple (is_valid, error_messages_list).
@@ -37,15 +39,15 @@ class LogService:
         if not date:
             errors.append("Date is required.")
 
-        # Validate Checklist Rules
-        for name, data in checklist_items.items():
-            rule = data.get("rule")
-            val = data.get("value")
+        if not skip_checklist:
+            for name, data in checklist_items.items():
+                rule = data.get("rule")
+                val = data.get("value")
 
-            if rule:
-                is_valid, err_msg = utils.validate_checklist_rule(val, rule)
-                if not is_valid:
-                    errors.append(f"Checklist '{name}': {err_msg}")
+                if rule:
+                    is_valid, err_msg = utils.validate_checklist_rule(val, rule)
+                    if not is_valid:
+                        errors.append(f"Checklist '{name}': {err_msg}")
 
         return len(errors) == 0, errors
 

--- a/flight_manager/ui/dialogs.py
+++ b/flight_manager/ui/dialogs.py
@@ -196,6 +196,42 @@ class PreferencesDialog(BaseSettingsDialog):
             f_frame, text="pts", font=("Segoe UI", 11)
         ).pack(side=tk.LEFT, padx=5)
 
+        ttk.Label(
+            tab, text="Default Parameter Path:", font=("Segoe UI", 11, "bold")
+        ).pack(anchor="w", pady=(0, 5))
+        ttk.Label(
+            tab,
+            text="Folder used as starting directory when browsing for parameters.",
+            font=("Segoe UI", 9),
+            foreground="gray"
+        ).pack(anchor="w", pady=(0, 5))
+        path_frame = ttk.Frame(tab)
+        path_frame.pack(fill=tk.X, pady=(0, 10))
+        self.default_param_path_var = tk.StringVar(
+            value=self.db.get_setting("default_param_path", "")
+        )
+        ttk.Entry(
+            path_frame,
+            textvariable=self.default_param_path_var,
+            font=("Segoe UI", 11)
+        ).pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(0, 5))
+        ttk.Button(
+            path_frame,
+            text="Browse...",
+            command=self._browse_default_param_path
+        ).pack(side=tk.LEFT)
+
+    def _browse_default_param_path(self):
+        """Opens a directory chooser for the default parameter path."""
+        current = self.default_param_path_var.get()
+        initial = current if current and os.path.isdir(current) else None
+        chosen = filedialog.askdirectory(
+            title="Select Default Parameter Folder",
+            initialdir=initial
+        )
+        if chosen:
+            self.default_param_path_var.set(chosen)
+
     def create_data_tab(self):
         """Creates the Data & Permissions tab."""
         tab = ttk.Frame(self.notebook, padding=20)
@@ -273,6 +309,7 @@ class PreferencesDialog(BaseSettingsDialog):
             self.db.set_setting(key, "1" if var.get() else "0")
         self.db.set_setting("log_max_size_gb", str(self.max_size_var.get()))
         self.db.set_setting("log_retention_days", str(self.retention_var.get()))
+        self.db.set_setting("default_param_path", self.default_param_path_var.get())
 
         if self.on_save_callback:
             self.on_save_callback(new_size)

--- a/flight_manager/ui/main_window.py
+++ b/flight_manager/ui/main_window.py
@@ -376,7 +376,6 @@ class FlightManagerApp:
         )
         self.combo_vehicle = ttk.Combobox(self.input_frame, state="readonly")
         self.combo_vehicle.grid(row=1, column=1, sticky="ew", pady=5)
-        self.combo_vehicle.bind("<<ComboboxSelected>>", self._on_vehicle_selected)
 
         # Flight ID
         ttk.Label(self.input_frame, text="Flight ID:").grid(
@@ -722,18 +721,6 @@ class FlightManagerApp:
             vehicle = self.combo_vehicle.get()
             if vehicle:
                 self.db.set_setting(f"last_param_path_{vehicle}", filename)
-
-    def _on_vehicle_selected(self, unused_event=None):
-        """Auto-populates param file with the last used path for the vehicle."""
-        vehicle = self.combo_vehicle.get()
-        if not vehicle:
-            return
-        last = self.db.get_setting(f"last_param_path_{vehicle}", "")
-        if last and os.path.exists(last):
-            self.entry_param_file.state(["!readonly"])
-            self.entry_param_file.delete(0, tk.END)
-            self.entry_param_file.insert(0, last)
-            self.entry_param_file.state(["readonly"])
 
     def browse_log_file(self):
         """Opens a file dialog to select a flight log file."""

--- a/flight_manager/ui/main_window.py
+++ b/flight_manager/ui/main_window.py
@@ -376,6 +376,7 @@ class FlightManagerApp:
         )
         self.combo_vehicle = ttk.Combobox(self.input_frame, state="readonly")
         self.combo_vehicle.grid(row=1, column=1, sticky="ew", pady=5)
+        self.combo_vehicle.bind("<<ComboboxSelected>>", self._on_vehicle_selected)
 
         # Flight ID
         ttk.Label(self.input_frame, text="Flight ID:").grid(
@@ -491,6 +492,9 @@ class FlightManagerApp:
         ttk.Button(btn_frame, text="Save Log", command=self.save_log).pack(
             side=tk.LEFT, padx=5
         )
+        ttk.Button(
+            btn_frame, text="Force Save", command=self.force_save_log
+        ).pack(side=tk.LEFT, padx=5)
         ttk.Button(btn_frame, text="Clear Form", command=self.clear_form).pack(
             side=tk.LEFT, padx=5
         )
@@ -695,13 +699,43 @@ class FlightManagerApp:
             self.sort_desc = True
         self.load_logs()
 
+    def _get_param_initial_dir(self) -> Optional[str]:
+        """Returns the best initial directory for the parameter file dialog."""
+        vehicle = self.combo_vehicle.get()
+        if vehicle:
+            last = self.db.get_setting(f"last_param_path_{vehicle}", "")
+            if last and os.path.exists(last):
+                return os.path.dirname(last)
+        default = self.db.get_setting("default_param_path", "")
+        if default and os.path.isdir(default):
+            return default
+        return None
+
     def browse_param_file(self):
         """Opens a file dialog to select a parameter file."""
-        filename = filedialog.askopenfilename(title="Select Parameter File")
+        filename = filedialog.askopenfilename(
+            title="Select Parameter File",
+            initialdir=self._get_param_initial_dir()
+        )
         if filename:
             self.entry_param_file.state(["!readonly"])
             self.entry_param_file.delete(0, tk.END)
             self.entry_param_file.insert(0, filename)
+            self.entry_param_file.state(["readonly"])
+            vehicle = self.combo_vehicle.get()
+            if vehicle:
+                self.db.set_setting(f"last_param_path_{vehicle}", filename)
+
+    def _on_vehicle_selected(self, unused_event=None):
+        """Auto-populates param file with the last used path for the vehicle."""
+        vehicle = self.combo_vehicle.get()
+        if not vehicle:
+            return
+        last = self.db.get_setting(f"last_param_path_{vehicle}", "")
+        if last and os.path.exists(last):
+            self.entry_param_file.state(["!readonly"])
+            self.entry_param_file.delete(0, tk.END)
+            self.entry_param_file.insert(0, last)
             self.entry_param_file.state(["readonly"])
 
     def browse_log_file(self):
@@ -914,6 +948,20 @@ class FlightManagerApp:
 
     def save_log(self):
         """Validates and initiates the log saving process."""
+        self._do_save_log(force=False)
+
+    def force_save_log(self):
+        """Saves the log ignoring preflight check failures after confirmation."""
+        if not messagebox.askyesno(
+            "Force Save",
+            "Preflight check validation will be skipped.\n"
+            "Are you sure you want to force save this log?"
+        ):
+            return
+        self._do_save_log(force=True)
+
+    def _do_save_log(self, force: bool = False):
+        """Core save logic used by both save_log and force_save_log."""
         flight_no = self.entry_flight_no.get().strip()
         date = self.log_date_var.get().strip()
         vehicle = self.combo_vehicle.get().strip()
@@ -926,7 +974,8 @@ class FlightManagerApp:
 
         # 1. Validate using LogService
         is_valid, errors = services.LogService.validate_log_entry(
-            flight_no, date, vehicle, self.dynamic_widgets
+            flight_no, date, vehicle, self.dynamic_widgets,
+            skip_checklist=force
         )
 
         if not is_valid:

--- a/flight_manager/ui/main_window.py
+++ b/flight_manager/ui/main_window.py
@@ -492,9 +492,6 @@ class FlightManagerApp:
         ttk.Button(btn_frame, text="Save Log", command=self.save_log).pack(
             side=tk.LEFT, padx=5
         )
-        ttk.Button(
-            btn_frame, text="Force Save", command=self.force_save_log
-        ).pack(side=tk.LEFT, padx=5)
         ttk.Button(btn_frame, text="Clear Form", command=self.clear_form).pack(
             side=tk.LEFT, padx=5
         )
@@ -947,21 +944,11 @@ class FlightManagerApp:
         self.entry_flight_no.insert(0, str(next_id))
 
     def save_log(self):
-        """Validates and initiates the log saving process."""
-        self._do_save_log(force=False)
+        """Validates and initiates the log saving process.
 
-    def force_save_log(self):
-        """Saves the log ignoring preflight check failures after confirmation."""
-        if not messagebox.askyesno(
-            "Force Save",
-            "Preflight check validation will be skipped.\n"
-            "Are you sure you want to force save this log?"
-        ):
-            return
-        self._do_save_log(force=True)
-
-    def _do_save_log(self, force: bool = False):
-        """Core save logic used by both save_log and force_save_log."""
+        If only preflight check items fail (not required fields), offers the
+        user the option to force save and bypass those failures.
+        """
         flight_no = self.entry_flight_no.get().strip()
         date = self.log_date_var.get().strip()
         vehicle = self.combo_vehicle.get().strip()
@@ -972,16 +959,29 @@ class FlightManagerApp:
         for name in self.dynamic_widgets:
             self.validate_item(name)
 
-        # 1. Validate using LogService
-        is_valid, errors = services.LogService.validate_log_entry(
-            flight_no, date, vehicle, self.dynamic_widgets,
-            skip_checklist=force
+        # Check required fields first (Flight ID, Date, Vehicle)
+        req_ok, req_errors = services.LogService.validate_log_entry(
+            flight_no, date, vehicle, {}, skip_checklist=True
         )
-
-        if not is_valid:
-            msg = "Validation Errors:\n\n" + "\n".join(errors)
-            messagebox.showwarning("Validation Failed", msg)
+        if not req_ok:
+            messagebox.showwarning(
+                "Validation Failed",
+                "Validation Errors:\n\n" + "\n".join(req_errors)
+            )
             return
+
+        # Check full validation including preflight checklist
+        is_valid, chk_errors = services.LogService.validate_log_entry(
+            flight_no, date, vehicle, self.dynamic_widgets
+        )
+        if not is_valid:
+            msg = (
+                "Preflight check failed:\n\n"
+                + "\n".join(chk_errors)
+                + "\n\nForce save anyway?"
+            )
+            if not messagebox.askyesno("Preflight Failed", msg):
+                return
 
         # Prepare Param Content
         param_file = self.entry_param_file.get().strip()
@@ -996,7 +996,7 @@ class FlightManagerApp:
                 )
                 return
 
-        # 2. Prepare Payload using LogService
+        # Prepare Payload using LogService
         log_data = services.LogService.prepare_log_payload(
             flight_no, date, vehicle, mission, note,
             self.dynamic_widgets, param_content

--- a/flight_manager/utils.py
+++ b/flight_manager/utils.py
@@ -128,10 +128,30 @@ def validate_checklist_rule(value: Any, rule_str: str) -> Tuple[bool, str]:
     return True, ""
 
 
+def _is_px4_qgc_format(content: str) -> bool:
+    """Returns True if content matches the PX4 QGroundControl tab-separated format."""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split("\t")
+        if len(parts) == 5:
+            try:
+                int(parts[0])  # Vehicle-Id
+                int(parts[1])  # Component-Id
+                int(parts[4])  # Type
+                return True
+            except ValueError:
+                pass
+        return False
+    return False
+
+
 def parse_params(content: str) -> Dict[str, str]:
     """Parses a string content into a dictionary of parameters.
 
-    Supports '=', ',' and whitespace delimiters. Ignores comments.
+    Supports ArduPilot ('=', ',', whitespace) and PX4 QGC tab-separated formats.
+    Ignores comment lines.
 
     Args:
         content: The string content of the parameter file.
@@ -141,6 +161,24 @@ def parse_params(content: str) -> Dict[str, str]:
     """
     params = {}
     if not content:
+        return params
+
+    # PX4 QGC format: Vehicle-Id\tComponent-Id\tName\tValue\tType
+    if _is_px4_qgc_format(content):
+        for line in content.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            parts = stripped.split("\t")
+            if len(parts) >= 4:
+                try:
+                    int(parts[0])  # validate it's a data line
+                    name = parts[2].strip()
+                    value = parts[3].strip()
+                    if name:
+                        params[name] = value
+                except (ValueError, IndexError):
+                    pass
         return params
 
     for line in content.splitlines():


### PR DESCRIPTION
# New Features

- **Parameter Path Memory** (#11): The app now remembers the last used parameter file path per vehicle and auto-fills the parameter field when switching vehicles. A default parameter folder can also be configured in Preferences → General, which is used as the starting directory when no vehicle-specific path is available.
- **Force Save Log** (#13): When a preflight check fails during save, a "Preflight Failed" dialog now offers a **Force save anyway?** option, allowing the log to be saved while bypassing checklist validation. Required fields (Flight ID, Date, Vehicle) are still enforced regardless.
- **PX4 QGroundControl Parameter Format** (#14): Parameter files saved by QGroundControl for PX4 stacks (tab-separated `Vehicle-Id Component-Id Name Value Type` format) are now correctly parsed and supported alongside the existing ArduPilot format.

# Bugs Fixed

- #14 Fixed parameter parsing failure for PX4 QGC parameter files, where the tab-separated format was not recognized and parameters could not be compared or stored correctly.

# Optimized

- **UI/UX**: Force save is surfaced contextually inside the existing preflight-failed dialog rather than as a standalone button, keeping the form clean.
- **Services**: `LogService.validate_log_entry` now accepts a `skip_checklist` flag, decoupling required-field validation from checklist rule validation.
- **Parameter parsing**: Auto-detects file format (PX4 QGC vs ArduPilot) before parsing, keeping existing behaviour intact for all non-PX4 files.