### PR TITLE
refactor the font system into a central FontManager

### DIFF
--- a/flight_manager/ui/calendar.py
+++ b/flight_manager/ui/calendar.py
@@ -11,6 +11,8 @@ from typing import Callable
 
 import tkcalendar
 
+from flight_manager.ui import theme
+
 
 class CalendarDialog(tk.Toplevel):
     """A modal dialog containing a calendar widget."""
@@ -57,6 +59,7 @@ class CalendarDialog(tk.Toplevel):
             month=self.current_date.month,
             day=self.current_date.day,
             date_pattern="y-mm-dd",
+            font=theme.MAIN,
         )  # Enforce ISO format
         self.cal.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
 

--- a/flight_manager/ui/dialogs.py
+++ b/flight_manager/ui/dialogs.py
@@ -9,10 +9,11 @@ import os
 import shutil
 import sqlite3
 import tkinter as tk
-from tkinter import filedialog, messagebox, scrolledtext, ttk
+from tkinter import filedialog, font, messagebox, scrolledtext, ttk
 from typing import Any, Callable, Optional
 
 from flight_manager import utils
+from flight_manager.ui import theme
 
 
 class BaseSettingsDialog(tk.Toplevel):
@@ -76,7 +77,7 @@ class BaseSettingsDialog(tk.Toplevel):
         container = ttk.Frame(parent)
         container.pack(fill=tk.BOTH, expand=True)
 
-        lb = tk.Listbox(container, height=list_height, font=("Segoe UI", 11))
+        lb = tk.Listbox(container, height=list_height, font=theme.MAIN)
         sb = ttk.Scrollbar(container, orient="vertical", command=lb.yview)
         lb.configure(yscrollcommand=sb.set)
 
@@ -131,11 +132,6 @@ class PreferencesDialog(BaseSettingsDialog):
         self.db = db_manager
         self.on_save_callback = on_save_callback
 
-        # Ensure Notebook tabs and buttons use the correct font
-        style = ttk.Style()
-        style.configure("TNotebook.Tab", font=("Segoe UI", 11))
-        style.configure("Settings.TButton", font=("Segoe UI", 11))
-
         self.notebook = ttk.Notebook(self)
         self.notebook.pack(fill=tk.BOTH, expand=True, padx=10, pady=(10, 5))
 
@@ -167,7 +163,7 @@ class PreferencesDialog(BaseSettingsDialog):
         ttk.Label(
             btn_frame,
             text="Note: Restart may be required.",
-            font=("Segoe UI", 9),
+            font=theme.SMALL,
             foreground="gray"
         ).pack(side=tk.LEFT, padx=5)
 
@@ -177,7 +173,7 @@ class PreferencesDialog(BaseSettingsDialog):
         self.notebook.add(tab, text="General")
 
         ttk.Label(
-            tab, text="Font Size:", font=("Segoe UI", 11, "bold")
+            tab, text="Font Size:", font=theme.BOLD
         ).pack(anchor="w", pady=(0, 5))
         current_size = int(self.db.get_setting("font_size", 10))
         self.size_var = tk.IntVar(value=current_size)
@@ -190,10 +186,10 @@ class PreferencesDialog(BaseSettingsDialog):
             to_=24,
             textvariable=self.size_var,
             width=10,
-            font=("Segoe UI", 11)
+            font=theme.MAIN
         ).pack(side=tk.LEFT)
         ttk.Label(
-            f_frame, text="pts", font=("Segoe UI", 11)
+            f_frame, text="pts", font=theme.MAIN
         ).pack(side=tk.LEFT, padx=5)
 
         ttk.Label(
@@ -238,7 +234,7 @@ class PreferencesDialog(BaseSettingsDialog):
         self.notebook.add(tab, text="Log Data")
 
         ttk.Label(
-            tab, text="Edit Permissions:", font=("Segoe UI", 11, "bold")
+            tab, text="Edit Permissions:", font=theme.BOLD
         ).pack(anchor="w", pady=(0, 5))
         self.vars = {}
         features = [
@@ -247,10 +243,6 @@ class PreferencesDialog(BaseSettingsDialog):
             ("enable_update_params", "Enable Update Parameters"),
             ("enable_update_log_file", "Enable Update Log File"),
         ]
-
-        # Style for checkbuttons to ensure font consistency
-        style = ttk.Style()
-        style.configure("Settings.TCheckbutton", font=("Segoe UI", 11))
 
         for key, label in features:
             var = tk.BooleanVar(value=self.db.get_setting(key, "1") == "1")
@@ -262,11 +254,11 @@ class PreferencesDialog(BaseSettingsDialog):
         ttk.Separator(tab, orient="horizontal").pack(fill=tk.X, pady=15)
 
         ttk.Label(
-            tab, text="Log Storage Management:", font=("Segoe UI", 11, "bold")
+            tab, text="Log Storage Management:", font=theme.BOLD
         ).pack(anchor="w", pady=(0, 5))
         ttk.Label(
             tab, text="Max Log Folder Size (GB, 0=Unlimited):",
-            font=("Segoe UI", 11)
+            font=theme.MAIN
         ).pack(anchor="w")
         current_max_size = float(self.db.get_setting("log_max_size_gb", "0"))
         self.max_size_var = tk.DoubleVar(value=current_max_size)
@@ -277,13 +269,13 @@ class PreferencesDialog(BaseSettingsDialog):
             increment=0.1,
             textvariable=self.max_size_var,
             width=10,
-            font=("Segoe UI", 11)
+            font=theme.MAIN
         ).pack(anchor="w", pady=(0, 10))
 
         ttk.Label(
             tab,
             text="Retention Period (Days, 0=Unlimited):",
-            font=("Segoe UI", 11)
+            font=theme.MAIN
         ).pack(anchor="w")
         current_retention = int(self.db.get_setting("log_retention_days", "0"))
         self.retention_var = tk.IntVar(value=current_retention)
@@ -293,7 +285,7 @@ class PreferencesDialog(BaseSettingsDialog):
             to_=9999,
             textvariable=self.retention_var,
             width=10,
-            font=("Segoe UI", 11)
+            font=theme.MAIN
         ).pack(anchor="w", pady=(0, 5))
 
     def apply_settings(self):
@@ -350,7 +342,7 @@ class IgnoreSettingsDialog(BaseSettingsDialog):
         add_frame.pack(fill=tk.X)
 
         add_frame.columnconfigure(0, weight=1)
-        self.entry_new = ttk.Entry(add_frame, font=("Segoe UI", 11))
+        self.entry_new = ttk.Entry(add_frame, font=theme.MAIN)
         self.entry_new.grid(row=0, column=0, sticky="ew", padx=(0, 10), ipady=3)
 
         ttk.Button(
@@ -426,7 +418,7 @@ class VehicleSettingsDialog(BaseSettingsDialog):
         add_frame.pack(fill=tk.X)
 
         add_frame.columnconfigure(0, weight=1)
-        self.entry_new = ttk.Entry(add_frame, font=("Segoe UI", 11))
+        self.entry_new = ttk.Entry(add_frame, font=theme.MAIN)
         self.entry_new.grid(row=0, column=0, sticky="ew", padx=(0, 10), ipady=3)
 
         ttk.Button(
@@ -925,9 +917,8 @@ class LogEditDialog(BaseSettingsDialog):
         note_frame = ttk.LabelFrame(main_frame, text="Note", padding=10)
         note_frame.pack(fill=tk.X, pady=5)
 
-        font_size = int(self.db.get_setting("font_size", 10))
         self.text_note = scrolledtext.ScrolledText(
-            note_frame, height=5, font=("Segoe UI", font_size)
+            note_frame, height=5, font=theme.MAIN
         )
         self.text_note.insert(tk.END, self.note if self.note else "")
         self.text_note.pack(fill=tk.BOTH, expand=True)
@@ -1035,13 +1026,12 @@ class ComparisonDialog(tk.Toplevel):
         self.combo.pack(side=tk.LEFT, padx=5, fill=tk.X, expand=True)
         self.combo.bind("<<ComboboxSelected>>", self.update_view)
 
-        font_size = int(self.db.get_setting("font_size", 10))
-        self.st = scrolledtext.ScrolledText(self, font=("Consolas", font_size))
+        self.st = scrolledtext.ScrolledText(self, font=theme.MONO)
         self.st.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
         self.st.tag_config("add", foreground="green")
         self.st.tag_config("rem", foreground="red")
         self.st.tag_config("chg", foreground="darkorange")
-        self.st.tag_config("head", font=("Consolas", font_size, "bold"))
+        self.st.tag_config("head", font=theme.MONO_BOLD)
 
     def load_history(self):
         """Loads parameter history for the vehicle."""
@@ -1234,9 +1224,8 @@ class FlightDetailsDialog(tk.Toplevel):
             note_frame = ttk.LabelFrame(self.container, text="Note", padding=10)
             note_frame.pack(fill=tk.X, padx=10, pady=5)
 
-            font_size = int(self.db.get_setting("font_size", 10))
             st = scrolledtext.ScrolledText(
-                note_frame, height=3, font=("Segoe UI", font_size)
+                note_frame, height=3, font=theme.MAIN
             )
             st.insert(tk.END, self.note)
             st.config(state="disabled")
@@ -1329,12 +1318,12 @@ class FlightDetailsDialog(tk.Toplevel):
             os.path.basename(self.log_path) if self.log_path else "None"
         )
 
-        font_size = int(self.db.get_setting("font_size", 10))
-        label_font = ("Segoe UI", font_size)
-
         if self.log_path and not file_exists:
             display_name += " [REMOVED]"
-            label_font = ("Segoe UI", font_size, "overstrike")
+            label_font = font.Font(font=theme.MAIN)
+            label_font.configure(overstrike=1)
+        else:
+            label_font = theme.MAIN
 
         self.lbl_log_file = tk.Label(
             log_frame, text=f"File: {display_name}", font=label_font

--- a/flight_manager/ui/main_window.py
+++ b/flight_manager/ui/main_window.py
@@ -11,7 +11,7 @@ import sqlite3
 import sys
 import threading
 import tkinter as tk
-from tkinter import filedialog, font, messagebox, scrolledtext, ttk
+from tkinter import filedialog, messagebox, scrolledtext, ttk
 from typing import Any, Dict, Optional
 
 from flight_manager import database
@@ -21,6 +21,7 @@ from flight_manager import utils
 from flight_manager import version
 from flight_manager.ui import calendar
 from flight_manager.ui import dialogs
+from flight_manager.ui import theme
 
 
 def get_resource_path(relative_path: str) -> str:
@@ -88,7 +89,8 @@ class FlightManagerApp:
 
         # Apply Global Font Size
         self.initial_font_size = int(self.db.get_setting("font_size", 10))
-        self.apply_font_size(self.initial_font_size)
+        self.font_manager = theme.FontManager(self.root)
+        self.font_manager.apply_size(self.initial_font_size)
 
         # State for Sorting/Filtering
         self.sort_col = "flight_no"
@@ -152,55 +154,10 @@ class FlightManagerApp:
             # If current date is invalid, reset to today
             self.filter_date.set(datetime.date.today().strftime("%Y-%m-%d"))
 
-    def apply_font_size(self, size: int):
-        """Applies a global font size to the application using named fonts.
-
-        Args:
-            size: The font size to apply.
-        """
-        # Update standard named fonts
-        for font_name in (
-            "TkDefaultFont",
-            "TkTextFont",
-            "TkMenuFont",
-            "TkHeadingFont",
-            "TkCaptionFont",
-            "TkSmallCaptionFont",
-        ):
-            f = font.nametofont(font_name)
-            f.configure(size=size)
-
-        # Update specific fonts used in the app
-        is_win = sys.platform == "win32"
-        main_font_family = "Segoe UI" if is_win else "Helvetica"
-        mono_font_family = "Consolas" if is_win else "Courier"
-
-        # Ensure our custom fonts exist and are updated
-        try:
-            custom_main = font.Font(
-                name="AppMainFont", family=main_font_family, size=size
-            )
-        except tk.TclError:
-            custom_main = font.nametofont("AppMainFont")
-            custom_main.configure(size=size)
-
-        try:
-            custom_mono = font.Font(
-                name="AppMonoFont", family=mono_font_family, size=size
-            )
-        except tk.TclError:
-            custom_mono = font.nametofont("AppMonoFont")
-            custom_mono.configure(size=size)
-
-        # Update TTK Styles
-        style = ttk.Style()
-        style.configure(".", font=("AppMainFont", size))
-        style.configure("Treeview.Heading", font=("AppMainFont", size, "bold"))
-
     def open_preferences(self):
         """Opens the Preferences dialog."""
         dialogs.PreferencesDialog(
-            self.root, self.db, on_save_callback=self.apply_font_size
+            self.root, self.db, on_save_callback=self.font_manager.apply_size
         )
 
     def pick_date(self, var: tk.StringVar, widget: tk.Widget = None):
@@ -476,9 +433,8 @@ class FlightManagerApp:
             row=7, column=0, sticky="nw", pady=5
         )
 
-        font_size = int(self.db.get_setting("font_size", 10))
         self.text_note = scrolledtext.ScrolledText(
-            self.input_frame, height=4, width=40, font=("Segoe UI", font_size)
+            self.input_frame, height=4, width=40, font=theme.MAIN
         )
         self.text_note.grid(
             row=7, column=1, columnspan=2, sticky="nsew", pady=5

--- a/flight_manager/ui/theme.py
+++ b/flight_manager/ui/theme.py
@@ -38,13 +38,14 @@ class FontManager:
         # Small font needs a size relative to the base, so defer the real size
         # to apply_size(). Create placeholders here so widgets can reference
         # the names immediately.
-        font.Font(name=MAIN, family=self._main_family, size=10)
-        font.Font(name=BOLD, family=self._main_family, size=10, weight="bold")
-        font.Font(name=SMALL, family=self._main_family, size=8)
-        font.Font(name=MONO, family=self._mono_family, size=10)
-        font.Font(
-            name=MONO_BOLD, family=self._mono_family, size=10, weight="bold"
-        )
+        # Store references to prevent garbage collection from deleting the fonts.
+        self._fonts = [
+            font.Font(root=self._root, name=MAIN, family=self._main_family, size=10),
+            font.Font(root=self._root, name=BOLD, family=self._main_family, size=10, weight="bold"),
+            font.Font(root=self._root, name=SMALL, family=self._main_family, size=8),
+            font.Font(root=self._root, name=MONO, family=self._mono_family, size=10),
+            font.Font(root=self._root, name=MONO_BOLD, family=self._mono_family, size=10, weight="bold"),
+        ]
 
     def apply_size(self, size: int):
         """Reconfigure every named font and TTK style to the given size.
@@ -53,14 +54,14 @@ class FontManager:
         """
         small_size = max(8, size - 2)
 
-        font.nametofont(MAIN).configure(size=size)
-        font.nametofont(BOLD).configure(size=size)
-        font.nametofont(SMALL).configure(size=small_size)
-        font.nametofont(MONO).configure(size=size)
-        font.nametofont(MONO_BOLD).configure(size=size)
+        font.nametofont(MAIN, root=self._root).configure(size=size)
+        font.nametofont(BOLD, root=self._root).configure(size=size)
+        font.nametofont(SMALL, root=self._root).configure(size=small_size)
+        font.nametofont(MONO, root=self._root).configure(size=size)
+        font.nametofont(MONO_BOLD, root=self._root).configure(size=size)
 
         for name in _STANDARD_TK_FONTS:
-            font.nametofont(name).configure(size=size)
+            font.nametofont(name, root=self._root).configure(size=size)
 
         style = ttk.Style()
         style.configure(".", font=(MAIN, size))

--- a/flight_manager/ui/theme.py
+++ b/flight_manager/ui/theme.py
@@ -1,0 +1,70 @@
+"""Central font and theme management for the Flight Manager UI.
+
+All named fonts and font-bearing TTK styles are owned by FontManager so that
+a single apply_size() call reconfigures the entire UI reactively.
+"""
+
+import sys
+import tkinter as tk
+from tkinter import font, ttk
+
+MAIN = "AppMainFont"
+BOLD = "AppBoldFont"
+SMALL = "AppSmallFont"
+MONO = "AppMonoFont"
+MONO_BOLD = "AppMonoBoldFont"
+
+_STANDARD_TK_FONTS = (
+    "TkDefaultFont",
+    "TkTextFont",
+    "TkMenuFont",
+    "TkHeadingFont",
+    "TkCaptionFont",
+    "TkSmallCaptionFont",
+)
+
+
+class FontManager:
+    """Owns every named font and font-bearing TTK style in the app."""
+
+    def __init__(self, root: tk.Misc):
+        is_win = sys.platform == "win32"
+        self._main_family = "Segoe UI" if is_win else "Helvetica"
+        self._mono_family = "Consolas" if is_win else "Courier"
+        self._root = root
+        self._create_named_fonts()
+
+    def _create_named_fonts(self):
+        # Small font needs a size relative to the base, so defer the real size
+        # to apply_size(). Create placeholders here so widgets can reference
+        # the names immediately.
+        font.Font(name=MAIN, family=self._main_family, size=10)
+        font.Font(name=BOLD, family=self._main_family, size=10, weight="bold")
+        font.Font(name=SMALL, family=self._main_family, size=8)
+        font.Font(name=MONO, family=self._mono_family, size=10)
+        font.Font(
+            name=MONO_BOLD, family=self._mono_family, size=10, weight="bold"
+        )
+
+    def apply_size(self, size: int):
+        """Reconfigure every named font and TTK style to the given size.
+
+        Widgets referencing the named fonts update automatically.
+        """
+        small_size = max(8, size - 2)
+
+        font.nametofont(MAIN).configure(size=size)
+        font.nametofont(BOLD).configure(size=size)
+        font.nametofont(SMALL).configure(size=small_size)
+        font.nametofont(MONO).configure(size=size)
+        font.nametofont(MONO_BOLD).configure(size=size)
+
+        for name in _STANDARD_TK_FONTS:
+            font.nametofont(name).configure(size=size)
+
+        style = ttk.Style()
+        style.configure(".", font=(MAIN, size))
+        style.configure("Treeview.Heading", font=(MAIN, size, "bold"))
+        style.configure("TNotebook.Tab", font=(MAIN, size))
+        style.configure("Settings.TButton", font=(MAIN, size))
+        style.configure("Settings.TCheckbutton", font=(MAIN, size))


### PR DESCRIPTION
Move every named-font and TTK-style font definition into a new
flight_manager/ui/theme.py FontManager. Replace hardcoded font tuples
across dialogs.py, main_window.py, and calendar.py with semantic named
fonts (AppMainFont, AppBoldFont, AppSmallFont, AppMonoFont,
AppMonoBoldFont), so that changing the font size in Preferences
updates every widget reactively. Also applies the named font to the
tkcalendar widget, which previously ignored the user's font size.

https://claude.ai/code/session_01PpK4YrhB8cu5iog2a2f2vF